### PR TITLE
Allow keyboard mapping for `markdown` type only

### DIFF
--- a/ftplugin/markdown/follow_markdown_links.vim
+++ b/ftplugin/markdown/follow_markdown_links.vim
@@ -19,5 +19,5 @@ endOfPython
 endfunction
 
 command! FollowLink call FollowLink()
-nnoremap <script> <CR> :FollowLink<CR>
-nnoremap <script> <BS> :e#<CR>
+autocmd FileType markdown nnoremap <script> <CR> :FollowLink<CR>
+autocmd FileType markdown nnoremap <script> <BS> :e#<CR>


### PR DESCRIPTION
Allow keyboard mappings for `markdown` file type only. Otherwise it interfere other plugins behaviour, like "Ag" when pressing <CR>. 