### PR TITLE
Support python3

### DIFF
--- a/ftplugin/markdown/follow_markdown_links.py
+++ b/ftplugin/markdown/follow_markdown_links.py
@@ -1,5 +1,9 @@
 import re
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from vim import *
 
 DEFAULT_EXTENSION = 'md'

--- a/ftplugin/markdown/follow_markdown_links.vim
+++ b/ftplugin/markdown/follow_markdown_links.vim
@@ -5,18 +5,33 @@ endif
 " --------------------------------
 " Add plugin to the path
 " --------------------------------
-python import sys
-python import vim
-python sys.path.append(vim.eval('expand("<sfile>:h")'))
+if has('python3')
+    python3 import sys
+    python3 import vim
+    python3 sys.path.append(vim.eval('expand("<sfile>:h")'))
 
-function! FollowLink()
-python << endOfPython
+    function! FollowLink()
+    python3 << endOfPython
 
 from follow_markdown_links import follow_link
 follow_link()
 
 endOfPython
-endfunction
+    endfunction
+else " python2
+    python import sys
+    python import vim
+    python sys.path.append(vim.eval('expand("<sfile>:h")'))
+
+    function! FollowLink()
+    python << endOfPython
+
+from follow_markdown_links import follow_link
+follow_link()
+
+endOfPython
+    endfunction
+endif
 
 command! FollowLink call FollowLink()
 nnoremap <script> <CR> :FollowLink<CR>


### PR DESCRIPTION
These changes enable the plugin to work for both Python 2 and Python 3.  They are necessary because some systems, for example recent Ubuntu versions, only enable Python 3 support by default.